### PR TITLE
Updated exclude.yml for MT protocol

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -22,10 +22,11 @@ dti_fa:
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 - sub-oxfordFmrib01  # registration issue (segmentation OK)
 mtr:
+- stanford  # Used different TR
+- fslAchieva  # Used different TR
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- stanford  # Used different TR.
 mtsat:
 - sub-geneva02  # TODO: check what's going on with this scan
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)

--- a/exclude.yml
+++ b/exclude.yml
@@ -24,11 +24,19 @@ mtr:
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 mtsat:
 - fslAchieva  # Used different TR and inconsistent within site
+- sub-fslAchieva03  # Poor data quality
+- sub-fslAchieva04  # Poor data quality
+- sub-fslAchieva05  # Poor data quality
+- sub-fslAchieva06  # Poor data quality
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 t1:
 - fslAchieva  # Used different TR and inconsistent within site
+- sub-fslAchieva03  # Poor data quality
+- sub-fslAchieva04  # Poor data quality
+- sub-fslAchieva05  # Poor data quality
+- sub-fslAchieva06  # Poor data quality
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)

--- a/exclude.yml
+++ b/exclude.yml
@@ -30,9 +30,12 @@ mtsat:
 - sub-geneva02  # TODO: check what's going on with this scan
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 - sub-tehranS04  # TODO: check what's going on with this scan
+- sub-fslAchieva04  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)
+- sub-beijingPrisma01  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)
 t1:
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- sub-fslAchieva03  # TODO: check what's going on with this scan
-- sub-fslAchieva04  # TODO: check what's going on with this scan
-- sub-fslAchieva05  # TODO: check what's going on with this scan
-- sub-fslAchieva06  # TODO: check what's going on with this scan
+- sub-fslAchieva03  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
+- sub-fslAchieva04  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
+- sub-fslAchieva05  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
+- sub-fslAchieva06  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
+- sub-beijingPrisma01  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)

--- a/exclude.yml
+++ b/exclude.yml
@@ -16,11 +16,6 @@ csa_gm:
 - sub-fslAchieva04  # Motion artifact
 - sub-vuiisIngenia04  # Motion artifact
 - sub-vuiisIngenia05  # Motion artifact
-dti_fa:
-- sub-beijingPrisma03  # wrong FOV placement
-- sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
-- sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- sub-oxfordFmrib01  # registration issue (segmentation OK)
 mtr:
 - stanford  # Used different TR
 - fslAchieva  # Used different TR
@@ -40,3 +35,18 @@ t1:
 - sub-fslAchieva05  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
 - sub-fslAchieva06  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
 - sub-beijingPrisma01  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)
+dti_fa:
+- sub-beijingPrisma03  # wrong FOV placement
+- sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
+- sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
+- sub-oxfordFmrib01  # registration issue (segmentation OK)
+dti_md:
+- sub-beijingPrisma03  # wrong FOV placement
+- sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
+- sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
+- sub-oxfordFmrib01  # registration issue (segmentation OK)
+fig_dti_rd:
+- sub-beijingPrisma03  # wrong FOV placement
+- sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
+- sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
+- sub-oxfordFmrib01  # registration issue (segmentation OK)

--- a/exclude.yml
+++ b/exclude.yml
@@ -28,22 +28,18 @@ mtsat:
 - sub-fslAchieva04  # Poor data quality
 - sub-fslAchieva05  # Poor data quality
 - sub-fslAchieva06  # Poor data quality
-- sub-nottwil03  # Poor data quality
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- sub-pavia05  # Poor data quality
 t1:
 - fslAchieva  # Used different TR and inconsistent within site
 - sub-fslAchieva03  # Poor data quality
 - sub-fslAchieva04  # Poor data quality
 - sub-fslAchieva05  # Poor data quality
 - sub-fslAchieva06  # Poor data quality
-- sub-nottwil03  # Poor data quality
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- sub-pavia05  # Poor data quality
 dti_fa:
 - sub-beijingPrisma03  # wrong FOV placement
 - sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)

--- a/exclude.yml
+++ b/exclude.yml
@@ -31,6 +31,7 @@ mtsat:
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
+- sub-pavia05  # Poor data quality
 t1:
 - fslAchieva  # Used different TR and inconsistent within site
 - sub-fslAchieva03  # Poor data quality
@@ -40,6 +41,7 @@ t1:
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
+- sub-pavia05  # Poor data quality
 dti_fa:
 - sub-beijingPrisma03  # wrong FOV placement
 - sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)

--- a/exclude.yml
+++ b/exclude.yml
@@ -28,6 +28,7 @@ mtsat:
 - sub-fslAchieva04  # Poor data quality
 - sub-fslAchieva05  # Poor data quality
 - sub-fslAchieva06  # Poor data quality
+- sub-nottwil03  # Poor data quality
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
@@ -38,6 +39,7 @@ t1:
 - sub-fslAchieva04  # Poor data quality
 - sub-fslAchieva05  # Poor data quality
 - sub-fslAchieva06  # Poor data quality
+- sub-nottwil03  # Poor data quality
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)

--- a/exclude.yml
+++ b/exclude.yml
@@ -45,7 +45,7 @@ dti_md:
 - sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 - sub-oxfordFmrib01  # registration issue (segmentation OK)
-fig_dti_rd:
+dti_rd:
 - sub-beijingPrisma03  # wrong FOV placement
 - sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)

--- a/exclude.yml
+++ b/exclude.yml
@@ -18,23 +18,20 @@ csa_gm:
 - sub-vuiisIngenia05  # Motion artifact
 mtr:
 - stanford  # Used different TR
-- fslAchieva  # Used different TR
+- fslAchieva  # Used different TR and inconsistent within site
 - sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
 - sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 mtsat:
-- sub-geneva02  # TODO: check what's going on with this scan
+- fslAchieva  # Used different TR and inconsistent within site
+- sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
+- sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- sub-tehranS04  # TODO: check what's going on with this scan
-- sub-fslAchieva04  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)
-- sub-beijingPrisma01  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)
 t1:
+- fslAchieva  # Used different TR and inconsistent within site
+- sub-beijingPrisma04  # different coil, shim value and FOV placement between MTon and MToff
+- sub-geneva02  # FOV positioning changed between MTon and MToff
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
-- sub-fslAchieva03  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
-- sub-fslAchieva04  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
-- sub-fslAchieva05  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
-- sub-fslAchieva06  # Bad TR (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
-- sub-beijingPrisma01  # Poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issue-690350212)
 dti_fa:
 - sub-beijingPrisma03  # wrong FOV placement
 - sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)


### PR DESCRIPTION
Added fslAchieva04 and beijingPrisma01 under `mtsat` due to poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-686536166).
Added information about bad TR for fslAchieva03-06 under `t1` (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-687112400)
Added sub-beijingPrisma01 under `t1` due to poor data quality (https://github.com/spine-generic/data-multi-subject/issues/36#issuecomment-686536166)

Should not we also exclude fslAchieva03-06 subjects with bad t1 TR also for `mtsat` when t1 is used for mtsat calculation?

https://github.com/spine-generic/spine-generic/blob/f07cde93193160f62a4e04f47c31a83d14b0f0a7/process_data.sh#L225-L226

Related to: https://github.com/spine-generic/data-multi-subject/issues/36