### PR TITLE
Fix broken link to analysis instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ get annex get sub-nwu01/ sub-nwu03/ sub-nwu04/ sub-oxfordFmrib04/ sub-tokyoSkyra
 
 ## Analysis
 
-The instructions to process this dataset are available in the [spine-generic documentation](https://spine-generic.readthedocs.io/en/latest/analysis_pipeline.html).
+The instructions to process this dataset are available in the [spine-generic documentation](https://spine-generic.readthedocs.io/en/latest/analysis-pipeline.html).
 
 ## Contributing
 


### PR DESCRIPTION
This PR fixes broken link to analysis instructions on the readthedocs website.