### PR TITLE
Lint .tsv

### DIFF
--- a/.github/workflows/lint-tsv
+++ b/.github/workflows/lint-tsv
@@ -1,0 +1,48 @@
+#!/usr/bin/env -S awk -f
+# lint .tsv files
+# - make sure every record is the same length
+# - make sure every field has content - even a null value should at least be '-'
+# <nick@kousu.ca> 2021, public domain
+#
+# TODO: package this for public consumption
+# TODO: make BSD-awk compatible
+
+BEGIN { FS="\t" }
+
+NR == 1 { NF_HEADER=NF }
+
+NF != NF_HEADER {
+  print "incorrect number of columns, line " NR
+  LINE_ERROR=1
+}
+
+{
+  for(i=1; i<=NF; i++) {
+
+    # strip surrounding whitespace
+    # is there a better way?
+    s=$i
+    sub(/(^[[:space:]]+)/, "", s)
+    sub(/([[:space:]]+)$/, "", s)
+    #print "|" $i "| -> |" s "|" # DEBUG
+
+    # check that each field is stripped and non-null.
+    if(length(s) == 0) {
+      print "empty field, line " NR ", column " i ". Please use '-' for null values."
+      LINE_ERROR=1
+    }
+    else if($i != s) {
+      print "extraneous whitespace, line " NR ", column " i ": '" $i "'"
+      LINE_ERROR=1
+    }
+
+  }
+}
+
+LINE_ERROR==1 {
+    print "errors in line " NR ": \n\t'" $0 "'\n"
+    ANY_ERROR=1
+    LINE_ERROR=0 # reset for next time
+}
+
+END { if(ANY_ERROR) { exit 1 } }

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -43,6 +43,9 @@ jobs:
           exit 1
         fi
 
+    - name: Lint participants.tsv
+      run: .github/workflows/lint-tsv participants.tsv
+
     #- name: Update software
     #  run: |
     #    # do we want to do this? it's helpful to avoid testing against surprise out-of-date software, but also so slow.


### PR DESCRIPTION
Fixes https://github.com/spine-generic/data-multi-subject/pull/57#issuecomment-702247465

This can detect three problems:

- an incorrect number of fields
- a fully empty field (because nulls should be "-")
- trailing whitespace

It doesn't directly detect using spaces instead of tabs, but if you do that you'll probably trip the incorrect count or the trailing whitespace detector. 

Example usage: After intentionally corrupting participants.tsv in each of the three ways:

```
$ .github/workflows/lint-tsv participants.tsv 
extraneous whitespace, line 2, column 4: '2019-02-12   '
errors in line 2: 
	'sub-amu01	M	28	2019-02-12   	amu	AMU - CEMEREM	Siemens	Verio	NeckMatrix	syngo_MR_B17	Virginie Callot'

empty field, line 3, column 7. Please use '-' for null values.
errors in line 3: 
	'sub-amu02	M	28	2019-02-13	amu	AMU - CEMEREM		Verio	NeckMatrix	syngo_MR_B17	Virginie Callot'

empty field, line 4, column 8. Please use '-' for null values.
errors in line 4: 
	'sub-amu03	F	28	2019-02-13	amu	AMU - CEMEREM	Siemens	    	NeckMatrix	syngo_MR_B17	Virginie Callot'

incorrect number of columns, line 6
errors in line 6: 
	'sub-amu05	F	39	2019-03-01	amu	AMU - CEMEREM	Siemens	Verio   syngo_MR_B17	Virginie Callot'

```

It's already added to `.gitub/workflows/validator.yml` to catch future glitches introduced by the Github web editor or whatever.

This is on top of #87 so please review + merge that first.