### PR TITLE
Add `git annex init` to download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then this will download the dataset:
 ```
 git clone https://github.com/spine-generic/data-multi-subject && \
 cd data-multi-subject && \
+git annex init && \
 git annex get .
 ```
 


### PR DESCRIPTION
This matches [the download instructions for `data-single-subject`](https://github.com/spine-generic/data-single-subject#download).

Addresses #113