### PR TITLE
add brain_t1 category into exclude.yml file (Issue #126)

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -55,3 +55,26 @@ dti_rd:
 - sub-mountSinai03  # T2w was re-acquired (hence wrong T2w -> DWI registration)
 - sub-oxfordFmrib04  # T1w scan is not aligned with other contrasts (subject repositioning)
 - sub-oxfordFmrib01  # registration issue (segmentation OK)
+brain_t1:
+- sub-barcelona01  # wrong FOV placement
+- sub-barcelona02  # wrong FOV placement
+- sub-barcelona03  # wrong FOV placement
+- sub-barcelona04  # wrong FOV placement
+- sub-barcelona05  # wrong FOV placement
+- sub-barcelona06  # wrong FOV placement
+- sub-beijingGE01  # signal loss in superior brain
+- sub-beijingGE02  # signal loss in superior brain
+- sub-beijingGE03  # signal loss in superior brain
+- sub-beijingGE04  # signal loss in superior brain
+- sub-beijingPrisma01  # wrong FOV placement
+- sub-beijingPrisma02  # wrong FOV placement
+- sub-beijingPrisma03  # wrong FOV placement
+- sub-beijingPrisma04  # wrong FOV placement
+- sub-beijingPrisma05  # wrong FOV placement
+- sub-fslAchieva06  # wrong FOV placement
+- sub-milan01  # wrong FOV placement
+- sub-milan02  # wrong FOV placement
+- sub-milan03  # wrong FOV placement
+- sub-milan04  # wrong FOV placement
+- sub-nwu01  # wrong FOV placement
+- sub-ucdavis07  # wrong FOV placement


### PR DESCRIPTION
Regarding issue #126 I have created the brain_t1 category in the [exclude.yml](https://github.com/spine-generic/data-multi-subject/blob/master/exclude.yml) file. There are **22** scans marked as unusable by Freesurfer. 

**Wrong FOV = 18 scans**
Example below
![Screen Shot 2022-07-18 at 3 05 54 PM](https://user-images.githubusercontent.com/98548430/179624443-20458e99-a2f2-4974-9fc4-f4360c1f254e.png)

**Signal loss = 4 scans**
Example below
![Screen Shot 2022-07-18 at 3 32 31 PM](https://user-images.githubusercontent.com/98548430/179624458-f07c12ea-9224-4bf7-bde1-25185b52f6ea.png)

