### PR TITLE
Add instruction for working from a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ See more at [the official documentation](https://git-annex.branchable.com/walkth
 
 > ⚠️ For advanced users only. Normally the instructions under [Download](#Download) should be enough.
 
-If you have forked this repository on Github (so that you have a copy `your-user-name/data-multi-subject` of `spine-generic/data-multi-subject`), you will need to take a few extra synchronization steps to get the latest data with `git annex get`.
+If you have forked this repository on Github (so that you have a copy `your-user-name/data-multi-subject` of `spine-generic/data-multi-subject`), you will need to take a few extra synchronization steps to get the latest data with `git annex get`. Otherwise, you may get an error message like:
+```
+get some-file-name.nii.gz (not available)
+  No other repository is known to contain the file.
+
+  (Note that these git remotes have annex-ignore set: origin)
+failed
+```
 
 1. In your local clone of `your-user-name/data-multi-subject`, make sure that `spine-generic/data-multi-subject` is also configured as a remote:
    ```
@@ -67,11 +74,13 @@ If you have forked this repository on Github (so that you have a copy `your-user
    If `spine-generic/data-multi-subject` is missing, you can add it with:
    ```
    git remote add upstream https://github.com/spine-generic/data-multi-subject.git
+   git config remote.upstream.annex-readonly true
    ```
 
 2. Then, to update your local clone, make sure to fetch the `git-annex` branch from `spine-generic/data-multi-subject` before running `git annex get`:
    ```
-   git fetch upstream && git pull && git annex get .
+   git fetch upstream +refs/heads/git-annex:refs/remotes/upstream/git-annex
+   git pull && git annex get .
    ```
 
 ## Analysis

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ git pull && git annex get .
 
 See more at [the official documentation](https://git-annex.branchable.com/walkthrough/) and take note of our [in-lab troubleshooting](https://github.com/neuropoly/data-management/blob/master/git-annex.md).
 
+## Working from a forked repository
+
+> ⚠️ For advanced users only. Normally the instructions under [Download](#Download) should be enough.
+
+If you have forked this repository on Github (so that you have a copy `your-user-name/data-multi-subject` of `spine-generic/data-multi-subject`), you will need to take a few extra synchronization steps to get the latest data with `git annex get`.
+
+1. In your local clone of `your-user-name/data-multi-subject`, make sure that `spine-generic/data-multi-subject` is also configured as a remote:
+   ```
+   git remote -v
+   # the answer should show both your-user-name/data-multi-subject.git (probably named "origin")
+   # and spine-generic/data-multi-subject (probably named "upstream")
+   ```
+
+   If `spine-generic/data-multi-subject` is missing, you can add it with:
+   ```
+   git remote add upstream https://github.com/spine-generic/data-multi-subject.git
+   ```
+
+2. Then, to update your local clone, make sure to fetch the `git-annex` branch from `spine-generic/data-multi-subject` before running `git annex get`:
+   ```
+   git fetch upstream && git pull && git annex get .
+   ```
+
 ## Analysis
 
 The instructions to process this dataset are available in the [spine-generic documentation](https://spine-generic.readthedocs.io/en/latest/analysis-pipeline.html).


### PR DESCRIPTION
Fixes #128.

After a long bout of debugging, we figured out that, when working from a clone of a fork of this repository, it's important to have up-to-date versions of the `git-annex` branch from the fork **and** from this repository before running `git annex get` (which will automatically reconcile information from all available `git-annex` branches). This can be done by configuring this repository as a remote called `upstream` for the clone, and running `git fetch upstream` before `git annex get`.

This pull request adds instructions to the readme to this effect.

Questions for the reviewers:

1. Are the instructions clear enough?
2. Is this too much of a niche case to include in the readme?
3. Should it also be copied to data-single-subject?

@renelabounek, I can't tag you as a reviewer, but if you have any thoughts I'd love to hear them.