### PR TITLE
Re-enable sg_params_checker in CI

### DIFF
--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -99,8 +99,7 @@ jobs:
 
     - name: Checking BIDS compliance
       run: bids-validator --verbose ./
-    # This check is disabled until we fix https://github.com/spine-generic/spine-generic/issues/264
-    #- name: Checking acquisition parameters
-    #  run: sg_params_checker -path-in ./
+    - name: Checking acquisition parameters
+      run: sg_params_checker -path-in ./
     - name: Checking data consistency
       run: sg_check_data_consistency -path-in ./


### PR DESCRIPTION
This was disabled in commit:
d9a155bad5286615697f20870b094f2048e90f3d

But as of the following PR, it no longer crashes:
https://github.com/spine-generic/spine-generic/issues/264