### PR TITLE
Revamp github actions validation workflow

### DIFF
--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # make sure to download directly from the PR's repo, whether that is this repo or a fork
         # By default github generates a merge commit for each PR in this repo, but only for the one branch under test

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -14,15 +14,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        # make sure to download directly from the PR's repo, whether that is this repo or a fork
-        # By default github generates a merge commit for each PR in this repo, but only for the one branch under test
-        # but `git-annex` needs access to *two* branches: the current branch and `git-annex`
-        # this might be subtly buggy since it is testing the remote version, not the merged version
-        #
-        # *if* this is not a pull request, this will fall back to its default behaviour.
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{ github.event.pull_request.head.ref }}
+      # since this workflow doesn't rely on git-annex, there's no need to take
+      # into account potential forks of the repo; we can just use github's
+      # auto-generated merge commit that lives in this repo
 
     - name: Install dos2unix
       run: |

--- a/.github/workflows/lint-participants.yml
+++ b/.github/workflows/lint-participants.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # make sure to download directly from the PR's repo, whether that is this repo or a fork
         # By default github generates a merge commit for each PR in this repo, but only for the one branch under test

--- a/.github/workflows/lint-participants.yml
+++ b/.github/workflows/lint-participants.yml
@@ -14,15 +14,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        # make sure to download directly from the PR's repo, whether that is this repo or a fork
-        # By default github generates a merge commit for each PR in this repo, but only for the one branch under test
-        # but `git-annex` needs access to *two* branches: the current branch and `git-annex`
-        # this might be subtly buggy since it is testing the remote version, not the merged version
-        #
-        # *if* this is not a pull request, this will fall back to its default behaviour.
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{ github.event.pull_request.head.ref }}
+      # since this workflow doesn't rely on git-annex, there's no need to take
+      # into account potential forks of the repo; we can just use github's
+      # auto-generated merge commit that lives in this repo
 
     - name: Lint participants.tsv
       run: .github/workflows/lint-tsv participants.tsv

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -36,9 +36,21 @@ jobs:
 
     - name: Install git-annex
       run: |
-        sudo apt-get install -y git-annex
+        sudo apt-get update
+        sudo apt-get --yes install git-annex
+        # the user name and email is needed by git-annex to write to
+        # the local git-annex branch
+        git config --global user.name "gh-actions"
+        git config --global user.email "gh-actions"
+        # save space by using hard links to annexed files
         git config --global annex.thin true
+        # retry for transient failures when downloading annexed file contents
         git config --global annex.retry 2
+
+    - name: Download dataset
+      run: |
+        git fetch --depth=1 origin git-annex:git-annex
+        git annex get -J8
 
     - name: Setup Deno (for bids-validator)
       uses: denoland/setup-deno@v2
@@ -51,22 +63,6 @@ jobs:
 # currently failing to install because of the python version
 #    - name: Install spine-generic for acquisition parameters check
 #      run: pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@master
-
-    - name: git config
-      run: |
-        # this is needed by git-annex so that it can write to the local git-annex branch
-        # the tracking information about the local copy
-        git config --global user.name "gh-actions"
-        git config --global user.email "gh-actions"
-        # but actually, disable those writes. We don't need them because we're throwing away this copy immediately.
-        # this might make the previous two lines unnecessary, but it's safer just to leave them both in
-        git config annex.alwayscommit false
-
-    - name: Download dataset
-      run: |
-        git fetch --depth=1 origin git-annex:git-annex # actions/checkout@v4 does a shallow checkout, so it is missing this important branch
-        git annex init
-        git annex get -J8
 
     - name: Checking BIDS compliance
       if: always()

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Checking BIDS compliance
       if: always()
       run: |
-        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR --allow-read=. jsr:@bids/validator . | tee bids.txt
+        deno run --no-prompt --allow-env --allow-read=. jsr:@bids/validator . | tee bids.txt
         printf "\nShort summary:\n\n"
         # FIXME: This should be replaced with bids-validator settings: A) throw error on warning or B) warning ignores
         ! grep "\[WARNING\]\|\[ERROR\]" bids.txt  # ! -> Reverse error code so "found == error thrown"

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -52,17 +52,17 @@ jobs:
         git fetch --depth=1 origin git-annex:git-annex
         git annex get -J8
 
-    - name: Setup Deno (for bids-validator)
+    - name: Install Deno
       uses: denoland/setup-deno@v2
 
-    - name: Set up Python
+    - name: Install Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.13
 
-# currently failing to install because of the python version
-#    - name: Install spine-generic for acquisition parameters check
-#      run: pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@master
+    - name: Install spine-generic
+      run: |
+        pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.9
 
     - name: Checking BIDS compliance
       if: always()

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -47,19 +47,17 @@ jobs:
         git config --global annex.thin true
         git config --global annex.retry 2
 
-    - name: Setup NodeJS (for bids-validator)
-      uses: actions/setup-node@v4
-
-    - name: Install bids-validator
-      run: sudo npm install -g bids-validator
+    - name: Setup Deno (for bids-validator)
+      uses: denoland/setup-deno@2
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
-    - name: Install spine-generic for acquisition parameters check
-      run: pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@master
+# currently failing to install because of the python version
+#    - name: Install spine-generic for acquisition parameters check
+#      run: pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@master
 
     - name: git config
       run: |
@@ -80,22 +78,22 @@ jobs:
     - name: Checking BIDS compliance
       if: always()
       run: |
-        bids-validator --verbose ./ | tee bids.txt
+        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR --allow-read=. jsr:@bids/validator . | tee bids.txt
         printf "\nShort summary:\n\n"
         # FIXME: This should be replaced with bids-validator settings: A) throw error on warning or B) warning ignores
-        ! grep "\[WARN\]\|\[ERR\]" bids.txt  # ! -> Reverse error code so "found == error thrown"
+        ! grep "\[WARNING\]\|\[ERROR\]" bids.txt  # ! -> Reverse error code so "found == error thrown"
 
-    - name: Checking acquisition parameters
-      if: always()
-      run: |
-        sg_params_checker -path-in ./ | tee params.txt
-        # FIXME: Checking the output like this should be replaced with SG throwing actual errors
-        ! grep "WARNING" params.txt  # ! -> Reverse error code so "found == error thrown"
-
-    - name: Checking data consistency
-      if: always()
-      run: |
-        sg_check_data_consistency -path-in ./ | tee consistency.txt
-        # FIXME: Checking the output like this should be replaced with SG throwing actual errors
-        ! grep "Warning\|Missing" consistency.txt
-        grep "all good" consistency.txt
+#    - name: Checking acquisition parameters
+#      if: always()
+#      run: |
+#        sg_params_checker -path-in ./ | tee params.txt
+#        # FIXME: Checking the output like this should be replaced with SG throwing actual errors
+#        ! grep "WARNING" params.txt  # ! -> Reverse error code so "found == error thrown"
+#
+#    - name: Checking data consistency
+#      if: always()
+#      run: |
+#        sg_check_data_consistency -path-in ./ | tee consistency.txt
+#        # FIXME: Checking the output like this should be replaced with SG throwing actual errors
+#        ! grep "Warning\|Missing" consistency.txt
+#        grep "all good" consistency.txt

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -1,5 +1,5 @@
-
 name: Dataset Validator
+
 on:
   push:
     branches: [ master ]
@@ -9,7 +9,6 @@ on:
 jobs:
   Validate:
     runs-on: ubuntu-latest
-
     steps:
 
     - name: Gain disk space by remapping temp disk (`/dev/sdb1`)
@@ -32,7 +31,7 @@ jobs:
         #
         # *if* this is not a pull request, this will fall back to its default behaviour.
         repository: ${{github.event.pull_request.head.repo.full_name}}
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{github.event.pull_request.head.ref}}
 
     - name: Install git-annex
       run: |
@@ -50,7 +49,7 @@ jobs:
     - name: Download dataset
       run: |
         git fetch --depth=1 origin git-annex:git-annex
-        git annex get -J8
+        git annex get --jobs 8
 
     - name: Install Deno
       uses: denoland/setup-deno@v2

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -48,7 +48,7 @@ jobs:
         git config --global annex.retry 2
 
     - name: Setup Deno (for bids-validator)
-      uses: denoland/setup-deno@2
+      uses: denoland/setup-deno@v2
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -70,16 +70,12 @@ jobs:
       # dependencies access any credentials that github CI exposes in environment variables, but at
       # least we're not giving it any network access, so exfiltrating them would require more effort.
       run: |
-        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR,IGNORE_TEST_WIN32 --allow-read=. jsr:@bids/validator .
+        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR,IGNORE_TEST_WIN32 --allow-read=. jsr:@bids/validator . || echo '::warning title=bids-validator::Errors found by bids-validator'
 
     - name: Run acquisition parameter validator
-      # we ignore the exit code because we expect warnings, but we still want
-      # to see them
       run: |
-        sg_params_checker -path-in . || true
+        sg_params_checker -path-in . || echo '::warning title=bids-validator::Errors found by sg_params_checker'
 
     - name: Run data consistency validator
-      # we ignore the exit code because we expect warnings, but we still want
-      # to see them
       run: |
-        sg_check_data_consistency -path-in . || true
+        sg_check_data_consistency -path-in . || echo '::warning title=bids-validator::Errors found by sg_check_data_consistency'

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -34,13 +34,6 @@ jobs:
         repository: ${{github.event.pull_request.head.repo.full_name}}
         ref: ${{ github.event.pull_request.head.ref }}
 
-    - name: Update apt packages
-      run: |
-        # do we want to do this? it's helpful to avoid testing against surprise out-of-date software, but also so slow.
-        sudo apt-get update &&
-        sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade &&
-        sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove
-
     - name: Install git-annex
       run: |
         sudo apt-get install -y git-annex

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -64,13 +64,13 @@ jobs:
       run: |
         pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.9
 
-    - name: Checking BIDS compliance
-      if: always()
+    - name: Run bids-validator
+      # If the explicit whitelist of allowed environment variables gets too annoying to update,
+      # we can loosen it to just a blanket `--allow-env`. This will let bids-validator and all of its
+      # dependencies access any credentials that github CI exposes in environment variables, but at
+      # least we're not giving it any network access, so exfiltrating them would require more effort.
       run: |
-        deno run --no-prompt --allow-env --allow-read=. jsr:@bids/validator . | tee bids.txt
-        printf "\nShort summary:\n\n"
-        # FIXME: This should be replaced with bids-validator settings: A) throw error on warning or B) warning ignores
-        ! grep "\[WARNING\]\|\[ERROR\]" bids.txt  # ! -> Reverse error code so "found == error thrown"
+        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR,IGNORE_TEST_WIN32 --allow-read=. jsr:@bids/validator .
 
 #    - name: Checking acquisition parameters
 #      if: always()

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -72,17 +72,14 @@ jobs:
       run: |
         deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR,IGNORE_TEST_WIN32 --allow-read=. jsr:@bids/validator .
 
-#    - name: Checking acquisition parameters
-#      if: always()
-#      run: |
-#        sg_params_checker -path-in ./ | tee params.txt
-#        # FIXME: Checking the output like this should be replaced with SG throwing actual errors
-#        ! grep "WARNING" params.txt  # ! -> Reverse error code so "found == error thrown"
-#
-#    - name: Checking data consistency
-#      if: always()
-#      run: |
-#        sg_check_data_consistency -path-in ./ | tee consistency.txt
-#        # FIXME: Checking the output like this should be replaced with SG throwing actual errors
-#        ! grep "Warning\|Missing" consistency.txt
-#        grep "all good" consistency.txt
+    - name: Run acquisition parameter validator
+      # we ignore the exit code because we expect warnings, but we still want
+      # to see them
+      run: |
+        sg_params_checker -path-in . || true
+
+    - name: Run data consistency validator
+      # we ignore the exit code because we expect warnings, but we still want
+      # to see them
+      run: |
+        sg_check_data_consistency -path-in . || true


### PR DESCRIPTION
Inspired by the recent revamp in https://github.com/spine-generic/data-single-subject/pull/34. (I decided to include the cosmetic changes to the workflow file as well, so that the two files are hopefully easier to keep in sync in the future.)

We want to see the validator output without blocking pull requests from merging, so the workflow basically always succeeds. But, there's an annotation for each validator that "fails" on the workflow summary page:
https://github.com/spine-generic/data-multi-subject/actions/runs/15402520048?pr=180